### PR TITLE
Rework panic and log handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-monitor.log
+/persist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "monitor"
 version = "0.1.0"
 edition = "2021"
+authors = [
+    "Mikhail Malyshev <mike.malyshev@gmail.com>",
+    "Dion Bramley <dionbramley@gmail.com>",
+]
+repository = "https://github.com/lf-edge/eve-monitor-rs"
 
 [profile.release]
 strip = "debuginfo" # Automatically strip symbols from the binary.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,45 +7,86 @@ mod terminal;
 mod traits;
 mod ui;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use application::Application;
 use libc::{EXIT_FAILURE, EXIT_SUCCESS};
-use log::{info, LevelFilter};
+use log::{info, warn, LevelFilter};
 use terminal::TerminalWrapper;
 
-fn init_logging() -> log2::Handle {
-    let log_dir = if let Ok(_dir) = std::env::var("XDG_RUNTIME_DIR") {
-        // store log in the current directory for convenience
-        // we use XDG_RUNTIME_DIR to detect the fact that we are running on desktop linux
-        PathBuf::from("./")
-    } else {
-        // get current data and time and use it as a log file name
-        let now = chrono::Local::now();
-        // make /persist/monitor-<date>-<time>/ folder path and create he folder
-        let log_dir = PathBuf::from(format!(
-            "/persist/monitor-{}",
-            now.format("%Y-%m-%d-%H-%M-%S")
-        ));
-        std::fs::create_dir_all(&log_dir).expect("Failed to create log directory");
-        // set EVE_MONITOR_LOG_DIR to the created folder
-        std::env::set_var("EVE_MONITOR_LOG_DIR", log_dir.to_string_lossy().to_string());
+const EVE_MONITOR_LOG_DIR_EVE: &str = "/persist/monitor/log";
+const EVE_MONITOR_LOG_DIR: &str = "./persist/monitor/log";
 
-        log_dir
-    };
+fn get_base_log_dir() -> &'static str {
+    // we use XDG_RUNTIME_DIR to detect the fact that we are running on desktop linux
+    // FIXME: is there a better way?
+    if let Ok(_dir) = std::env::var("XDG_RUNTIME_DIR") {
+        EVE_MONITOR_LOG_DIR
+    } else {
+        EVE_MONITOR_LOG_DIR_EVE
+    }
+}
+
+fn remove_old_log_sessions<T: AsRef<Path>>(log_dir: T, rotate_count: usize) -> Result<()> {
+    // go over log directory and remove old sessions
+    // starting from the oldest one while we do not reach rotate_count
+    // subdirectories in format %Y-%m-%d-%H-%M-%S
+
+    // use walkdir to go over all subdirectories. get directory name and convert to date time object
+    let mut dirs = std::fs::read_dir(&log_dir.as_ref())?
+        // ignot not directories
+        .filter(|entry| entry.as_ref().map(|e| e.path().is_dir()).unwrap_or(false))
+        .filter_map(|entry| {
+            entry.ok().and_then(|entry| {
+                entry
+                    .file_name()
+                    .into_string()
+                    .ok()
+                    .and_then(|name| {
+                        chrono::NaiveDateTime::parse_from_str(&name, "%Y-%m-%d-%H-%M-%S").ok()
+                    })
+                    .map(|dt| (entry.path(), dt))
+            })
+        })
+        .collect::<Vec<_>>();
+    // then sort by date time and remove oldest directories
+    dirs.sort_by_key(|(_, dt)| *dt);
+    while dirs.len() > rotate_count - 1 {
+        let (dir, _) = dirs.remove(0);
+        std::fs::remove_dir_all(dir)?;
+    }
+    Ok(())
+}
+
+fn init_logging() -> log2::Handle {
+    let base_log_dir = get_base_log_dir();
+
+    // remove old log directories. store result until we initialize logging
+    let remove_result = remove_old_log_sessions(base_log_dir, 3);
+
+    // get current data and time and use it as a subdirectory name for logs
+    let current_dir = chrono::Local::now().format("%Y-%m-%d-%H-%M-%S").to_string();
+    let log_dir = PathBuf::from(format!("{}/{}", base_log_dir, current_dir));
+    std::fs::create_dir_all(&log_dir).expect("Failed to create log directory");
+    // set EVE_MONITOR_LOG_DIR to the created folder. it is used later in panic handler
+    std::env::set_var("EVE_MONITOR_LOG_DIR", log_dir.to_string_lossy().to_string());
 
     let log_file = log_dir.join("monitor.log").to_string_lossy().to_string();
 
     let handle = log2::open(&log_file)
-        .size(10 * 1024 * 1024)
-        .rotate(20)
+        .size(1024 * 1024)
+        .rotate(10)
         .tee(false) // no console output
         .module(true)
         .level(LevelFilter::Debug)
         .start();
 
     info!("Logging initialized: {:?}", log_file);
+
+    if let Err(e) = remove_result {
+        warn!("Failed to remove old log sessions: {}", e);
+    }
 
     handle
 }
@@ -64,28 +105,35 @@ pub fn initialize_panic_handler() -> Result<()> {
         let _ = TerminalWrapper::close_terminal();
 
         let msg = format!("{}", panic_hook.panic_report(panic_info));
-        #[cfg(not(debug_assertions))]
-        {
-            eprintln!("{msg}");
-            use human_panic::{handle_dump, print_msg, Metadata};
-            let author = format!("authored by {}", env!("CARGO_PKG_AUTHORS"));
-            let support = format!(
-                "You can open a support request at {}",
-                env!("CARGO_PKG_REPOSITORY")
-            );
-            let meta = Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
-                .authors(author)
-                .support(support);
 
-            let file_path = handle_dump(&meta, panic_info);
-            print_msg(file_path, &meta)
-                .expect("human-panic: printing error message to console failed");
-        }
+        eprintln!("{msg}");
+        use human_panic::{handle_dump, print_msg, Metadata};
+        let support = format!(
+            "You can open a bug report at {}",
+            env!("CARGO_PKG_REPOSITORY")
+        );
+        let meta = Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+            .authors("LF-EDGE EVE OS project")
+            .support(support);
+
+        // FIXME: set TMPDIR to value of EVE_MONITOR_LOG_DIR before calling handle_dump
+        // or panic report won't be saved on EVE
+        // we can remove it when human-panic is fixed
+        // see https://github.com/rust-cli/human-panic/issues/167
+        let _ = std::env::var("EVE_MONITOR_LOG_DIR").and_then(|log_dir| {
+            std::env::set_var("TMPDIR", log_dir);
+            Ok(())
+        });
+
+        let file_path = handle_dump(&meta, panic_info);
+        print_msg(file_path, &meta).expect("human-panic: printing error message to console failed");
+
         log::error!("Error: {}", strip_ansi_escapes::strip_str(msg));
 
         #[cfg(debug_assertions)]
         {
             // Better Panic stacktrace that is only enabled when debugging.
+            // we do not have space on real TTY to display it
             better_panic::Settings::auto()
                 .most_recent_first(false)
                 .lineno_suffix(true)
@@ -99,6 +147,8 @@ pub fn initialize_panic_handler() -> Result<()> {
 }
 
 fn log_system_info() {
+    // log monitor version
+    info!("Starting monitor version: {}", env!("CARGO_PKG_VERSION"));
     // get current user UID and GID
     use std::os::unix::fs::MetadataExt;
     std::fs::metadata("/proc/self")


### PR DESCRIPTION
- Logs are now saved in /persist/monitor/log/<date-time> directory
- now we have a log rotation on directory level i.e. old directories are removed. Current value is 3 session.
- updated Cargo.toml to display more info in panic report
- panic report is now saved into the same directory as logs
- panic report is now generated in debug builds together with better_panic panic rendering