### PR TITLE
gha: add test coverage to pr ci/cd

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,3 +44,24 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      
+      - name: Generate coverage
+        run: |
+          cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+          cargo llvm-cov report --html --output-dir coverage
+          
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage


### PR DESCRIPTION
informative html report to see test coverage of the system. I've added this to nkv, you can check report [here](https://github.com/nkval/nkv/actions/runs/16500195254?pr=57) in artifacts